### PR TITLE
Docs need an extra underscore

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,5 +16,5 @@ Under the hood `zipa` transforms your imports into clients. It follows a simple
 convention: `HOSTNAME__PREFIX`. For the hostname, single underscores are
 translated into dots and for the prefix into slashes.
 
-For example: `api_twitter_com__v1` becomes `https://api.twitter.com/v1`. The
+For example: `api_twitter_com___v1` becomes `https://api.twitter.com/v1`. The
 prefix part is optional.


### PR DESCRIPTION
Very minor but important typo in the docs. To get the leading backslash for the URI prefix three underscores are needed.
